### PR TITLE
add alias parameter

### DIFF
--- a/phocagallery.php
+++ b/phocagallery.php
@@ -125,6 +125,7 @@ class plgContentPhocaGallery extends JPlugin
                 // Plugin variables
                 $view = '';
                 $id   = 0;
+                $category_alias   = '';
                 $max  = 0;
                 $imageid				= 0;
                 $limitstart = 0;
@@ -152,7 +153,8 @@ class plgContentPhocaGallery extends JPlugin
                     if ($values[0] == 'view') {                 $view = $values[1];}
                     else if ($values[0] == 'id') {              $id = $values[1];}
                     else if ($values[0] == 'categoryid') {      $id = $values[1];}// Backward compatibility - categoryid is alias for id
-                    else if($values[0]=='imageid')			{$imageid				= $values[1];}
+                    else if ($values[0] == 'alias') {           $category_alias = $values[1];}
+                    else if ($values[0]=='imageid')			{$imageid				= $values[1];}
                     else if ($values[0] == 'max') {             $max = $values[1];}
                     else if ($values[0] == 'limitstart') {             $limitstart = $values[1];}
                     else if ($values[0] == 'limitcount') {             $limitcount = $values[1];}
@@ -496,6 +498,18 @@ class plgContentPhocaGallery extends JPlugin
 
 
                 if ($view == 'category') {
+                    //------- add by zhang, query category's id -------------
+                    if (!$category_alias) {
+                        $queryc = 'SELECT a.id'
+                            . ' FROM #__phocagallery_categories AS a'
+                            . ' WHERE a.alias = \'' . $category_alias . '\'';
+                        $db->setQuery($queryc);
+                        $outcome_data = $db->loadObjectList();
+                        if (!empty($outcome_data)) {
+                            $id = $outcome_data[0]->id;
+                        }
+                    }
+                    //----------------------------------
 
                     $this->_setPluginNumberCategoryView();
                     $layoutBI 	= new FileLayout('box_image', null, array('component' => 'com_phocagallery'));


### PR DESCRIPTION
Recently, I've been using phocagallery to manage images for my website, and I'm going to use phocagallery in my articles. But when displaying category in the article, I can only use category's id as a parameter, which is very inconvenient because there are many categories in the picture and it is difficult to remember.
So, I added a parameter category's alias.
For example:
{phocagallery view=category|alias=antenna-module}

Thank you for the great work phocagallery.